### PR TITLE
Fix DateTime parsing on query change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "QueryBuilder",
-    "version": "1.2.3",
+    "version": "1.2.1",
     "description": "Query Builder",
     "thingworxServer": "http://localhost:8015",
     "thingworxUser": "Administrator",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "QueryBuilder",
-    "version": "1.2.1",
+    "version": "1.2.3",
     "description": "Query Builder",
     "thingworxServer": "http://localhost:8015",
     "thingworxUser": "Administrator",

--- a/src/QueryBuilder.runtime.ts
+++ b/src/QueryBuilder.runtime.ts
@@ -82,7 +82,7 @@ class QueryBuilder extends TWRuntimeWidget {
                 } 
                 switch (this.dataShape.fieldDefinitions[rule.id].baseType) {
                     case 'DATETIME':
-                        filter.value = +moment(rule.value, 'DD/MM/YYYY HH:mm:ss');
+                        filter.value = this.convertDateTimeToTimestamp(rule.value);
                         break;
                     default:
                         filter.value = rule.value;
@@ -111,8 +111,8 @@ class QueryBuilder extends TWRuntimeWidget {
                 } 
                 switch (this.dataShape.fieldDefinitions[rule.id].baseType) {
                     case 'DATETIME':
-                        filter.from = +moment(rule.value[0], 'DD/MM/YYYY HH:mm:ss');
-                        filter.to = +moment(rule.value[1], 'DD/MM/YYYY HH:mm:ss');
+                        filter.from = this.convertDateTimeToTimestamp(rule.value[0]);
+                        filter.to = this.convertDateTimeToTimestamp(rule.value[1]);
                         break;
                     default:
                         filter.from = rule.value[0];
@@ -151,6 +151,11 @@ class QueryBuilder extends TWRuntimeWidget {
         if (containsValidQuery || isQueryEmpty) {
             this.jqElement.triggerHandler('QueryChanged');
         }
+    }
+
+    convertDateTimeToTimestamp(value) {
+        const momentObject = moment(value, 'DD/MM/YYYY HH:mm:ss');
+        return momentObject.isValid() ? +momentObject : +moment(value);
     }
 
     getQueryState(rules: RuleGroup) {


### PR DESCRIPTION
## Problem
If a query contains already saved date-time field and this query will be changed (any field except date-time one), date-time value became "Invalid date". This happens because the widget saves date-time values as timestamps, but trying to parse it as a new date-time value ('DD/MM/YYYY HH:mm:ss').

## Implementation
Fixed date-time converting. If parsing of 'DD/MM/YYYY HH:mm:ss' format is not valid, passing value to the moment object without format assuming that value is a timestamp.