### PR TITLE
CIG-69 Workflow action filters - Jobs stalling if a parenthesis is used in filtering

### DIFF
--- a/src/QueryBuilder.runtime.ts
+++ b/src/QueryBuilder.runtime.ts
@@ -1,6 +1,8 @@
 import { ThingworxRuntimeWidget, TWProperty } from 'typescriptwebpacksupport/widgetRuntimeSupport'
 import { queryToObject } from './twxQueryToQueryBuilder';
 
+const SPECIAL_CHARS = /(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|:|\/)/g;
+
 export interface Rule {
     id?: string,
     field: string,
@@ -95,13 +97,13 @@ class QueryBuilder extends TWRuntimeWidget {
                 filter.value = false;
                 break;
             case 'begins_with':
-                filter.value = rule.value + '%';
+                filter.value = rule.value.replace(SPECIAL_CHARS, '\\$&') + '%';
                 break;
             case 'ends_with':
-                filter.value = '%' + rule.value;
+                filter.value = '%' + rule.value.replace(SPECIAL_CHARS, '\\$&');
                 break;
             case 'contains':
-                filter.value = '%' + rule.value + '%';
+                filter.value = '%' + rule.value.replace(SPECIAL_CHARS, '\\$&') + '%';
                 break;
             case 'between':
             case 'not_between':

--- a/src/twxQueryToQueryBuilder.ts
+++ b/src/twxQueryToQueryBuilder.ts
@@ -1,5 +1,7 @@
 import { Rule, RuleGroup, TwxQuery } from "./QueryBuilder.runtime";
 
+const ESCAPED_SPECIAL_SYMBOLS = /(\\)((\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|:|\/))/g;
+
 interface GenericTwxQuery {
     query: TwxQuery;
     convertToRule(): Rule | RuleGroup;
@@ -60,7 +62,7 @@ class LikeQuery implements GenericTwxQuery {
         return {
             field: this.query.fieldName,
             operator: rule,
-            value: value,
+            value: value.replace(ESCAPED_SPECIAL_SYMBOLS, '$2'),
             id: this.query.fieldName
         };
     }


### PR DESCRIPTION
Add escaping special characters after user input and add unescaping special characters before displaying on ui